### PR TITLE
Fix/compiler error

### DIFF
--- a/esp32-wifi-thermostat/RingBuffer.h
+++ b/esp32-wifi-thermostat/RingBuffer.h
@@ -17,11 +17,11 @@ template <typename T, uint16_t Size>
 class RingBuffer {
 private:
 	const uint16_t size;
-	uint16_t count;
 	T buf[Size];
 	T* write_p;
 	T* read_p;
 	T* end_p;
+	uint16_t count;
 public:
 	RingBuffer() : size(Size), write_p(buf), read_p(buf), end_p(buf + Size), count(0) {}
 

--- a/esp32-wifi-thermostat/esp32-wifi-thermostat.ino
+++ b/esp32-wifi-thermostat/esp32-wifi-thermostat.ino
@@ -1,5 +1,5 @@
 /*
- Name:		esp32_wifi_thermostat.ino 
+ Name:		esp32_wifi_thermostat.ino
  Author:	DIYLESS
 */
 #ifdef ESP32
@@ -134,10 +134,10 @@ float pid(float sp, float pv, float pv_last, float& ierr, float dt) {
     // calculate the integral error
     ierr = ierr + KI * error * dt;
     // calculate the measurement derivative
-    float dpv = (pv - pv_last) / dt;
+    //float dpv = (pv - pv_last) / dt;
     // calculate the PID output
     float P = KP * error; //proportional contribution
-    float I = ierr; //integral contribution  
+    float I = ierr; //integral contribution
     float op = P + I;
     // implement anti-reset windup
     if ((op < oplo) || (op > ophi)) {


### PR DESCRIPTION
New compiler rules do not want unused variables and order of constructor variables and private variables differently. This will fix it